### PR TITLE
x-coordinate should be along width, y along the height

### DIFF
--- a/generate_adv_data_coco.py
+++ b/generate_adv_data_coco.py
@@ -91,8 +91,8 @@ for i, data in enumerate(pbar):
     if args.random:
         h = x.shape[1]
         w = x.shape[2]
-        xmin = np.random.randint(0, h - patch_height)
-        ymin = np.random.randint(0, w - patch_width)
+        ymin = np.random.randint(0, h - patch_height)
+        xmin = np.random.randint(0, w - patch_width)
     else:
         xmin = 0
         ymin = 0


### PR DESCRIPTION
xmin is being set from the height and ymin is being set from the width of the image. After generating the adversarial images, the adversarial patch isn't showing sometimes (when ymin + patch_height exceeds 'h').  Instead, ymin should be along the height and xmin along the width.